### PR TITLE
Add verbosity-controlled messaging for sandbox game

### DIFF
--- a/sandboxgame/src/sandboxgame/game.py
+++ b/sandboxgame/src/sandboxgame/game.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .core import EnemyType, GameState, Vector3
 from .utils.io import InputManager
+from .utils.messages import print_message
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,10 @@ class SandboxGame:
     def initialize(self) -> None:
         if self.headless:
             logger.info("Sandbox game initialized in headless mode; rendering disabled.")
+            print_message(
+                "Headless mode active - skipping window/context initialization.",
+                level=1,
+            )
             return
         if not HAVE_GLFW or glfw is None:
             raise RuntimeError("GLFW is not available; cannot create window.")
@@ -138,9 +143,12 @@ class SandboxGame:
     # Main loop
 
     def run(self) -> None:
+        print_message("Initializing sandbox game...", level=1)
         self.initialize()
         self._running = True
         self._last_time = time.perf_counter()
+
+        print_message("Starting main loop.", level=1)
 
         while self._running:
             if not self.headless:
@@ -157,6 +165,7 @@ class SandboxGame:
             if self.headless:
                 # In headless mode ``run`` performs a single simulation tick.
                 self._running = False
+                print_message("Headless tick complete.", level=2)
                 continue
 
             self._render_scene()
@@ -164,6 +173,7 @@ class SandboxGame:
 
         if not self.headless and glfw is not None:
             glfw.terminate()
+        print_message("Sandbox game loop terminated.", level=1)
 
     def _tick(self, dt: float) -> None:
         if not self.headless:
@@ -184,6 +194,7 @@ class SandboxGame:
 
         if self.game_state.is_game_over():
             logger.info("Player defeated - exiting main loop.")
+            print_message("Player defeated - exiting main loop.", level=1)
             self._running = False
 
     # ------------------------------------------------------------------

--- a/sandboxgame/src/sandboxgame/utils/__init__.py
+++ b/sandboxgame/src/sandboxgame/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers used across the sandboxgame package."""
+
+from .messages import print_message, set_verbosity
+
+__all__ = ["print_message", "set_verbosity"]

--- a/sandboxgame/src/sandboxgame/utils/messages.py
+++ b/sandboxgame/src/sandboxgame/utils/messages.py
@@ -1,0 +1,23 @@
+"""Lightweight verbosity-aware messaging helpers."""
+
+from __future__ import annotations
+
+from typing import Final
+
+_DEFAULT_VERBOSITY: Final[int] = 0
+_current_verbosity: int = _DEFAULT_VERBOSITY
+
+
+def set_verbosity(level: int) -> None:
+    """Set the active verbosity level for sandboxgame CLI feedback."""
+    global _current_verbosity
+    _current_verbosity = max(0, int(level))
+
+
+def print_message(message: str, *, level: int = 1) -> None:
+    """Print *message* when the configured verbosity permits it."""
+    if level <= _current_verbosity:
+        print(message)
+
+
+__all__ = ["print_message", "set_verbosity"]


### PR DESCRIPTION
## Summary
- add a utils.messages module providing module-level verbosity helpers
- export the messaging utilities from the utils package for reuse
- use the verbosity-aware printer inside the SandboxGame lifecycle for CLI feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caaeb93360832ab659b83b47b70c26