### PR TITLE
Add CLI verbosity control for sandbox game

### DIFF
--- a/sandboxgame/src/sandboxgame/game.py
+++ b/sandboxgame/src/sandboxgame/game.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import argparse
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 from .core import EnemyType, GameState, Vector3
 from .utils.io import InputManager
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_VERBOSITY = 1
+VERBOSITY_LEVELS = {
+    0: logging.WARNING,
+    1: logging.INFO,
+    2: logging.DEBUG,
+}
 
 
 try:  # pragma: no cover - OpenGL is optional during tests
@@ -307,11 +315,42 @@ class SandboxGame:
         glPopMatrix()
 
 
-def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+def apply_cli_verbosity(verbosity: int) -> logging.Logger:
+    """Configure logging for the CLI based on the requested verbosity."""
+
+    level = VERBOSITY_LEVELS.get(verbosity, logging.INFO)
+    logging.basicConfig(level=level)
+
+    cli_logger = logging.getLogger("sandboxgame.cli")
+    message_level = logging.INFO if level <= logging.INFO else level
+    cli_logger.log(
+        message_level,
+        "Sandbox House Defense CLI starting (verbosity=%s)",
+        verbosity,
+    )
+    return cli_logger
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Sandbox House Defense CLI")
+    parser.add_argument(
+        "--verbosity",
+        choices=tuple(VERBOSITY_LEVELS.keys()),
+        default=DEFAULT_VERBOSITY,
+        type=int,
+        help="Control CLI logging verbosity (0=warnings, 1=info, 2=debug).",
+    )
+    args = parser.parse_args(argv)
+
+    apply_cli_verbosity(args.verbosity)
+
     game = SandboxGame()
     game.run()
 
 
 __all__ = ["SandboxGame", "SandboxConfig", "main"]
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- extend `sandboxgame.game.main` to parse CLI arguments, support a `--verbosity` flag, and accept optional argv input
- implement `apply_cli_verbosity` to configure logging based on the requested verbosity and emit an initial status message before the game starts
- add an executable module guard so `python -m sandboxgame.game` launches the runtime loop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68caaeb61554832ab9b9cc48e6f23d3a