### PR TITLE
Add CLI entry point and regression test for sandboxgame

### DIFF
--- a/sandboxgame/pyproject.toml
+++ b/sandboxgame/pyproject.toml
@@ -26,5 +26,8 @@ tests = [
 Homepage = "https://example.com/sandboxgame"
 Repository = "https://example.com/sandboxgame/repo"
 
+[project.scripts]
+sandboxgame = "sandboxgame.game:main"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sandboxgame/tests/test_cli.py
+++ b/sandboxgame/tests/test_cli.py
@@ -1,0 +1,33 @@
+"""Tests for the sandboxgame command line interface."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import sandboxgame.game as game_module
+
+
+def test_main_accepts_verbosity_option(monkeypatch) -> None:
+    """Ensure ``main`` parses verbosity flags and runs the game."""
+
+    recorded = {}
+
+    class DummyGame:
+        def __init__(self) -> None:
+            recorded["instantiated"] = True
+
+        def run(self) -> None:
+            recorded["run"] = True
+
+    def fake_apply_cli_verbosity(level: int) -> None:
+        recorded["verbosity"] = level
+
+    monkeypatch.setattr(game_module, "SandboxGame", DummyGame)
+    monkeypatch.setattr(game_module, "apply_cli_verbosity", fake_apply_cli_verbosity)
+
+    game_module.main(["--verbosity", "2"])
+
+    assert recorded == {"instantiated": True, "verbosity": 2, "run": True}


### PR DESCRIPTION
## Summary
- register a console script so the sandboxgame CLI is available as `sandboxgame`
- add a regression test that ensures the CLI accepts the verbosity option without running the game loop

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab278bdec832a810afdd1e1782d5a