### PR TITLE
Ensure initial enemies spawn in front of the player

### DIFF
--- a/sandboxgame/src/sandboxgame/game.py
+++ b/sandboxgame/src/sandboxgame/game.py
@@ -101,7 +101,7 @@ class SandboxGame:
     def _spawn_initial_enemies(self) -> None:
         self.game_state.spawn_enemy(EnemyType.BRUTE, Vector3(-4.0, 0.5, 6.0))
         self.game_state.spawn_enemy(EnemyType.SPRINTER, Vector3(4.0, 0.5, 6.0))
-        self.game_state.spawn_enemy(EnemyType.LURKER, Vector3(0.0, 3.5, -6.0))
+        self.game_state.spawn_enemy(EnemyType.LURKER, Vector3(0.0, 3.5, 8.0))
 
     def initialize(self) -> None:
         if self.headless:


### PR DESCRIPTION
## Summary
- ensure the Lurker enemy spawned during game initialization uses a positive Z coordinate so it starts in front of the player

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab3d6fac8832aaba8dd3953980c38